### PR TITLE
fix guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Useage:
 2. Edit `config.toml`
 
     ```toml
-    [params]
+    [params.assets]
     css = ["css/light.css", "css/dark.css"]
     ```
 


### PR DESCRIPTION
In step 2 of README guidance, `[params]` was changed to `[params.assets]`. Otherwise it didn't work.